### PR TITLE
Add urgent flag to builds api

### DIFF
--- a/lib/deckard/build.ex
+++ b/lib/deckard/build.ex
@@ -21,7 +21,8 @@ defmodule Deckard.Build do
             version: data["distro_version"],
             sha_sum: data["sha_sum"],
             size: String.to_integer(data["byte_size"]),
-            url: build_url(data["path"])
+            url: build_url(data["path"]),
+            urgent: Keyword.get(data, "urgent", false)
           }
 
           {:ok, release}

--- a/lib/deckard/build.ex
+++ b/lib/deckard/build.ex
@@ -22,7 +22,7 @@ defmodule Deckard.Build do
             sha_sum: data["sha_sum"],
             size: String.to_integer(data["byte_size"]),
             url: build_url(data["path"]),
-            urgent: Keyword.get(data, "urgent", false)
+            urgent: Map.get(data, "urgent", false)
           }
 
           {:ok, release}

--- a/web/controllers/build_controller.ex
+++ b/web/controllers/build_controller.ex
@@ -8,9 +8,11 @@ defmodule Deckard.BuildController do
       {:error, :not_found} ->
         conn
         |> send_resp(:not_found, "")
+
       {:error, _reason} ->
         conn
         |> send_resp(:internal_server_error, "")
+
       {:ok, build} ->
         conn
         |> put_resp_content_type("application/json")

--- a/web/views/build_view.ex
+++ b/web/views/build_view.ex
@@ -6,7 +6,8 @@ defmodule Deckard.BuildView do
       version: build.version,
       sha_sum: build.sha_sum,
       size: build.size,
-      url: build.url
+      url: build.url,
+      urgent: build.urgent
     }
   end
 end


### PR DESCRIPTION
This is needed for the recovery partition upgrades.