### PR TITLE
Add support for multiple architectures

### DIFF
--- a/lib/deckard/build.ex
+++ b/lib/deckard/build.ex
@@ -3,8 +3,8 @@ defmodule Deckard.Build do
 
   defstruct [:channel, :build, :version, :sha_sum, :size, :url, :urgent]
 
-  def find(arch, version, channel) do
-    case Redis.query(["HGETALL", redis_key(arch, version, channel)]) do
+  def find(version, arch, channel) do
+    case Redis.query(["HGETALL", redis_key(version, arch, channel)]) do
       [] ->
         {:error, :not_found}
 
@@ -32,8 +32,8 @@ defmodule Deckard.Build do
     end
   end
 
-  defp redis_key(_arch, "17.10", channel), do: "pop_release:#{channel}"
-  defp redis_key(arch, version, channel), do: "pop_release:#{version}_#{arch}_#{channel}"
+  defp redis_key("17.10", _arch, channel), do: "pop_release:#{channel}"
+  defp redis_key(version, arch, channel), do: "pop_release:#{version}_#{arch}_#{channel}"
 
   defp build_url(path) do
     root_url =

--- a/lib/deckard/build.ex
+++ b/lib/deckard/build.ex
@@ -3,8 +3,8 @@ defmodule Deckard.Build do
 
   defstruct [:channel, :build, :version, :sha_sum, :size, :url, :urgent]
 
-  def find(version, channel) do
-    case Redis.query(["HGETALL", redis_key(version, channel)]) do
+  def find(arch, version, channel) do
+    case Redis.query(["HGETALL", redis_key(arch, version, channel)]) do
       [] ->
         {:error, :not_found}
 
@@ -32,13 +32,8 @@ defmodule Deckard.Build do
     end
   end
 
-  defp redis_key(version, channel) do
-    if version == "17.10" do
-      "pop_release:#{channel}"
-    else
-      "pop_release:#{version}_amd64_#{channel}"
-    end
-  end
+  defp redis_key(_arch, "17.10", channel), do: "pop_release:#{channel}"
+  defp redis_key(arch, version, channel), do: "pop_release:#{version}_#{arch}_#{channel}"
 
   defp build_url(path) do
     root_url =

--- a/web/controllers/build_controller.ex
+++ b/web/controllers/build_controller.ex
@@ -3,8 +3,9 @@ defmodule Deckard.BuildController do
 
   alias Deckard.Build
 
-  def show(conn, %{"version" => version, "channel" => channel}) do
-    case Build.find(version, channel) do
+  def show(conn, %{"version" => version, "channel" => channel} = params) do
+    arch = Map.get(params, "arch", "amd64")
+    case Build.find(arch, version, channel) do
       {:error, :not_found} ->
         conn
         |> send_resp(:not_found, "")

--- a/web/controllers/build_controller.ex
+++ b/web/controllers/build_controller.ex
@@ -5,7 +5,7 @@ defmodule Deckard.BuildController do
 
   def show(conn, %{"version" => version, "channel" => channel} = params) do
     arch = Map.get(params, "arch", "amd64")
-    case Build.find(arch, version, channel) do
+    case Build.find(version, arch, channel) do
       {:error, :not_found} ->
         conn
         |> send_resp(:not_found, "")


### PR DESCRIPTION
Allows consuming multi-architecture builds. Prepares for Amd64 releases. 

Maintains compatibility with old api by keeping amd64 as the default architecture.