### PR TITLE
Fix arch url param

### DIFF
--- a/web/controllers/build_controller.ex
+++ b/web/controllers/build_controller.ex
@@ -5,6 +5,7 @@ defmodule Deckard.BuildController do
 
   def show(conn, %{"version" => version, "channel" => channel} = params) do
     arch = Map.get(params, "arch", "amd64")
+
     case Build.find(version, arch, channel) do
       {:error, :not_found} ->
         conn

--- a/web/endpoint.ex
+++ b/web/endpoint.ex
@@ -5,6 +5,11 @@ defmodule Deckard.Endpoint do
     plug Phoenix.CodeReloader
   end
 
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Jason
+
   plug Plug.Logger
   plug CORSPlug
 


### PR DESCRIPTION
Previous PR had a bug due to old Phoenix version not expanding `params` with query parameters. Added Pug parser that handles that. All working fine, tested on https://api.pop-os.org/builds/21.10/raspi?arch=arm64